### PR TITLE
Add builder.toml to make builder image creation easy

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,0 +1,17 @@
+[[buildpacks]]
+id = "io.buildpacks.samples.nodejs"
+uri = "file://nodejs-buildpack"
+
+[[buildpacks]]
+id = "io.buildpacks.samples.java"
+uri = "file://java-buildpack"
+
+[[groups]]
+buildpacks = [
+  { id = "io.buildpacks.samples.java", version = "0.0.1" },
+]
+
+[[groups]]
+buildpacks = [
+  { id = "io.buildpacks.samples.nodejs", version = "0.0.1" },
+]


### PR DESCRIPTION
To use the builder.toml, download the latest "pack" cli version and run:

pack create-builder [IMAGE NAME] -b builder.toml