### PR TITLE
Add a Gradle buildpack

### DIFF
--- a/gradle-buildpack/README.md
+++ b/gradle-buildpack/README.md
@@ -1,0 +1,4 @@
+# Sample: Java Gradle Buildpack
+
+Compatible apps:
+- Gradle apps

--- a/gradle-buildpack/bin/build
+++ b/gradle-buildpack/bin/build
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+echo "---> Gradle buildpack"
+
+set -eo pipefail
+
+env_dir="$2/env"
+layers_dir="$1"
+plan_path="$3"
+
+jdk_url="https://cdn.azul.com/zulu/bin/zulu8.28.0.1-jdk8.0.163-linux_x64.tar.gz"
+jdk_version="1.8.0_163"
+
+# Load user-provided build-time environment variables
+if compgen -G "$env_dir/*" > /dev/null; then
+  for var in "$env_dir"/*; do
+    declare "$(basename "$var")=$(<"$var")"
+  done
+fi
+
+echo "---> Installing JDK"
+
+# If it doesn't exist locally, create a JDK cache layer
+# This makes JDK available to subsequent buildpacks as well.
+if [[ -f $layers_dir/jdk.toml ]]; then
+  cached_jdk_url=$(cat "$layers_dir/jdk.toml" | yj -t | jq -r .metadata.url 2>/dev/null || echo 'JDK TOML parsing failed')
+fi
+if [[ $jdk_url != $cached_jdk_url ]] ; then
+  rm -rf "$layers_dir"/jdk
+  mkdir -p "$layers_dir"/jdk/env
+  wget -q -O - "$jdk_url" | tar pxz -C "$layers_dir"/jdk --strip-components=1
+  echo "launch = true" > "$layers_dir"/jdk.toml
+  echo "build = true" >> "$layers_dir"/jdk.toml
+  echo "cache = true" >> "$layers_dir"/jdk.toml
+  echo -e "[metadata]\n  version = \"$jdk_version\"\n  url = \"$jdk_url\"" >> "$layers_dir"/jdk.toml
+
+  echo "$layers_dir"/jdk > "$layers_dir"/jdk/env/JAVA_HOME
+  if [[ -z $LD_LIBRARY_PATH ]]; then
+    echo "$JAVA_HOME/jre/lib/amd64/server" > $layers_dir/jdk/env/LD_LIBRARY_PATH
+  else
+    echo "$JAVA_HOME/jre/lib/amd64/server:$LD_LIBRARY_PATH" > $layers_dir/jdk/env/LD_LIBRARY_PATH
+  fi
+
+  mkdir -p $layers_dir/jdk/profile.d
+  cat << EOF > $layers_dir/jdk/profile.d/jdk.sh
+export JAVA_HOME=$layers_dir/jdk
+if [[ -z \$LD_LIBRARY_PATH ]]; then
+  export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server"
+else
+  export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:$LD_LIBRARY_PATH"
+fi
+EOF
+fi
+# Set env variables to make jdk accessible
+for var in "$layers_dir"/jdk/env/*; do
+  declare "$(basename "$var")=$(<"$var")"
+done
+export PATH=$layers_dir/jdk/bin:$PATH
+
+target_dir="build/libs"
+
+if [[ ! -d $layers_dir/gradle ]]; then
+  mkdir -p $layers_dir/gradle
+  echo "cache = true" > $layers_dir/gradle.toml
+fi
+ln -s $layers_dir/gradle $HOME/.gradle
+
+echo "---> Running Gradle Wrapper"
+./gradlew clean build -x test --no-daemon
+
+# Set default start command
+for jarFile in $(find "$target_dir" -maxdepth 1 -name "*.jar" -type f); do
+  echo "processes = [{ type = \"web\", command = \"java -jar $jarFile\"}]" > "$layers_dir/launch.toml"
+  break;
+done

--- a/gradle-buildpack/bin/detect
+++ b/gradle-buildpack/bin/detect
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [[ -f build.gradle ]]; then
+    exit 0
+fi
+
+exit 1

--- a/gradle-buildpack/buildpack.toml
+++ b/gradle-buildpack/buildpack.toml
@@ -1,0 +1,7 @@
+[buildpack]
+id = "io.buildpacks.samples.gradle"
+version = "0.0.1"
+name = "Sample Gradle Buildpack"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
this supersedes #19 and adds a few improvements. Notably, I've removed support for apps w/o a Gradle wrapper in order to simplify the sample.