### PR TITLE
Update buildpack.toml with valid metadata.

### DIFF
--- a/hello-world-buildpack/buildpack.toml
+++ b/hello-world-buildpack/buildpack.toml
@@ -1,4 +1,7 @@
+[buildpack]
 id = "io.buildpacks.samples.buildpack.hello-world"
 version = "0.0.1"
 name = "Hello World Buildpack"
-stacks = ["packs/v3"]
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
The sample hello-world-buildpack no longer seems to work with pack 0.0.9. It looks like the buildpack.toml is no longer correct. This PR has the update I needed to make it work on my machine w/pack 0.0.9.