### PR TITLE
Update builder.toml

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -9,7 +9,7 @@ uri = "./java-buildpack"
 latest = true
 
 [[groups]]
-buildpacks = [ { id = "io.buildpacks.samples.nodejs", version = "latest" } ]
+buildpacks = [ { id = "io.buildpacks.samples.java", version = "latest" } ]
 
 [[groups]]
-buildpacks = [ { id = "io.buildpacks.samples.java", version = "latest" } ]
+buildpacks = [ { id = "io.buildpacks.samples.nodejs", version = "latest" } ]


### PR DESCRIPTION
This moves the Node.js buildpack to the last position in `order.toml`, which will prevent it from being used on apps that have a `package.json` but don't want to run the node buildpack (a very common case).